### PR TITLE
API Key updates, general cleanup

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,24 +9,13 @@
         precompressed br
     }
 
-    @missingHeader {
-        not header Authorization {$API_KEY}
-    }
-
-    @unauthorizedMethods {
-        not method GET
-        not header Authorization {$API_KEY}
-    }
-
-    # reverse proxy GET requests to the posts collection
-    handle /api/collections/posts/records* {
-        respond @unauthorizedMethods  "Forbidden" 403
+    # Handle API requests
+    handle /api/* {
         reverse_proxy {$POCKETBASE_URL}
     }
 
-    # Any other requests require the API key
-    handle /api/* {
-        respond @missingHeader  "Forbidden" 403
+    # Handle access to the Pocketbase Portal
+    handle /_/* {
         reverse_proxy {$POCKETBASE_URL}
     }
 }

--- a/fly.toml
+++ b/fly.toml
@@ -24,7 +24,7 @@ primary_region = "lhr"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 256
 
 [mounts]
     source = "pb_data"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,13 +3,9 @@
     import Post from "./lib/Post.svelte";
     import IntersectionObserver from "svelte-intersection-observer";
     import ScrollToTop from "./lib/ScrollToTop.svelte";
+    import type { PostData } from "./models/postdata.model";
 
-    class PostData {
-        track_id!: string;
-        description: string | undefined;
-        live_date!: string;
-    }
-
+    let element: HTMLElement;
     let posts: PostData[] = [];
     let visiblePosts = 3;
     let endOfData = false;
@@ -40,7 +36,6 @@
         await getPosts();
     });
 
-    let element: HTMLElement;
     function handleIntersection() {
         if (!loading && !endOfData) {
             getPosts();
@@ -57,11 +52,7 @@
     <div class="container">
         {#each posts as post}
             <div>
-                <Post
-                    trackId={post.track_id}
-                    live_date={post.live_date}
-                    description={post.description}
-                />
+                <Post data={post} />
             </div>
         {/each}
 

--- a/src/lib/Post.svelte
+++ b/src/lib/Post.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    export let trackId: string;
-    export let live_date: string;
-    export let description: string | undefined;
+    import type { PostData } from "../models/postdata.model";
 
-    let src = `https://open.spotify.com/embed/track/${trackId}?utm_source=generator`;
-    let title = new Date(live_date).toLocaleDateString("en-GB", {
+    export let data: PostData;
+
+    let src = `https://open.spotify.com/embed/track/${data.track_id}?utm_source=generator`;
+    let title = new Date(data.live_date).toLocaleDateString("en-GB", {
         day: "numeric",
         weekday: "long",
         month: "long",
@@ -28,9 +28,9 @@
         <h2 class="title">{title}</h2>
     </div>
 
-    {#if description}
+    {#if data.description}
         <div>
-            <p class="description">- "<em>{description}</em>"</p>
+            <p class="description">- "<em>{data.description}</em>"</p>
         </div>
     {/if}
 </div>

--- a/src/models/postdata.model.ts
+++ b/src/models/postdata.model.ts
@@ -1,0 +1,5 @@
+export type PostData = {
+    track_id: string;
+    description: string | undefined;
+    live_date: string;
+}


### PR DESCRIPTION
Integrating with Gitbutler has butchered this PR and I am unable to recover it. 

This update includes the following:
- Remove API key requirement from Caddy
  - As I am now exposing the Pocketbase Admin Portal on `/_/` we can set more specific collection-based authentication requirements, rather than having Caddy cover every `/api/*` endpoint
- Update to pass whole `Post` model to the Svelte component, rather than each piece of data.
- Update `fly.toml` to reduce RAM usage
  - The VM running https://noongmt.com on fly.io was rarely going above 128mb of RAM usage so I reduced the allocated resources directly. This updates the config to prevent it from increasing again on deployment.